### PR TITLE
Fixes Apache misconfiguration

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,6 @@
+<Files ~ "\.db$">
+  Order allow,deny
+  Deny from all
+</Files>
+RewriteEngine On
+RewriteRule uploads/ - [F,L]

--- a/download.php
+++ b/download.php
@@ -1,0 +1,28 @@
+<?php
+// this action requires an authorized user
+require_once "auth.php";
+
+// a valid request has to contain a file to be downloaded
+if (!isset($_GET['file']) || empty($_GET['file'])) {
+  header('Bad Request', true, 400);
+  exit();
+}
+
+// avoid directory traversal vulnerability
+$filename = basename($_GET['file']);
+
+// load location of upload-directory from config
+$conf = parse_ini_file("palma.ini", true);
+
+$filepath = $conf['path']['upload_dir'].'/'.$filename;
+
+if (file_exists($filepath)) {
+  // file exists: return file for download
+  header('Content-Type: application/octet-stream');
+  header('Content-Disposition: attachment; filename="'.addslashes($filename).'"');
+  readfile($filepath);
+} else {
+  // file does not exist: 404 Not Found
+  header('Not Found', true, 404);
+  exit();
+}

--- a/index.php
+++ b/index.php
@@ -209,11 +209,8 @@ function downloadFile(screensection) {
    var file = document.getElementById("file" + screensection).innerHTML;
    var file = document.getElementById("file" + screensection).getAttribute("title");
 
-   // Download direkt
-   var download = url_path[0]+"/"+url_path[1]+"/"+url_path[2]+"/"+url_path[3]+"/uploads/"+file;
-
-   // alternatively with download area?
-   // var download = "download.php";
+   // Download with download.php
+   var download = url_path[0]+"/"+url_path[1]+"/"+url_path[2]+"/"+url_path[3]+"/download.php?file="+encodeURIComponent(file);
 
    var name = "Download";
 


### PR DESCRIPTION
The SQLite-database ```palma.db``` should never be sent to any client (see [TODO](https://github.com/UB-Mannheim/PalMA/blob/master/TODO)) and no client should access files in the ```uploads/```-directory. This commit fixes a **arbitrary code execution vulnerability**.