### PR TITLE
Fix shellcheck notices in /scripts, travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 # Travis configuration for PalMA
 
-sudo: false
-
 language: php
 
+sudo: required
+dist: trusty
+
 # php-codesniffer is used for the PSR-2 conformance test.
-addons:
-  apt:
-    packages:
-      - php-codesniffer
-      - libperl-critic-perl
-      - shellcheck
+# Need the wily repos for shellcheck
+before_install:
+  - echo "deb http://archive.ubuntu.com/ubuntu/ wily universe" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -yq php-codesniffer libperl-critic-perl shellcheck
 
 script:
-      - bash docs/dist/pre-commit.sh .
-      - bash docs/dist/pre-push.sh
+  - bash docs/dist/pre-commit.sh .
+  - bash docs/dist/pre-push.sh

--- a/docs/dist/php-codesniffer.sh
+++ b/docs/dist/php-codesniffer.sh
@@ -25,7 +25,7 @@
 #------------------------------------------------------------------------------
 
 DIR="$(dirname "$(readlink -f "$0")")"
-PHP_CODE_STANDARD=${PHP_CODE_STANDARD:-PSR2}
+PHP_CODE_STANDARD=${PHP_CODE_STANDARD:-$DIR}
 CS_PHAR="$DIR/phpcs.phar"
 CS_URL='https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar'
 
@@ -39,4 +39,4 @@ if [[ -z "$CODE_SNIFFER" ]];then
     CODE_SNIFFER="php $CS_PHAR"
 fi
 
-$CODE_SNIFFER --standard="$PHP_CODE_STANDARD" "$@"
+$CODE_SNIFFER --standard="$PHP_CODE_STANDARD" -s "$@"

--- a/docs/dist/pre-commit.sh
+++ b/docs/dist/pre-commit.sh
@@ -7,7 +7,7 @@
 # SYNOPSIS
 #         make .git/hooks/pre-commit
 #         # or
-#         ln -s ../../pre-commit.sh .git/hooks
+#         ln -s ../../docs/dist/pre-commit.sh .git/hooks/pre-commit
 #
 #         git add ... && git commit;
 #
@@ -50,10 +50,12 @@ if [[ "${#staged_php[@]}" -ne 0 ]];then
 fi
 
 # If any Shell (bash) scripts are staged
-staged_shell=($($git_diff|grep '\.sh$'))
+staged_shell=()
+staged_shell+=($($git_diff|grep '\.sh$'))
+staged_shell+=($($git_diff|grep '^\(./\)\?scripts/'))
 if [[ "${#staged_shell[@]}" -ne 0 ]];then
     if which shellcheck >/dev/null; then
-        out=$(shellcheck --shell bash "${staged_shell[@]}")
+        out=$(shellcheck --shell=bash "${staged_shell[@]}")
         if [[ ! -z "$out" ]];then
             echo "$out";
             exit 1;

--- a/docs/dist/ruleset.xml
+++ b/docs/dist/ruleset.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<ruleset name="ubma-phpcs-rules">
+    <description>UB Mannheim PHP code checking rules</description>
+    <!-- Include the whole PSR-2 standard -->
+    <rule ref="PSR2">
+        <!-- https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php#L177 -->
+        <exclude name="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace"/>
+        <!-- https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php -->
+        <exclude name="Generic.Functions.FunctionCallArgumentSpacing"/>
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+        <exclude name="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed"/>
+    </rule>
+    <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect"><severity>4</severity></rule>
+    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace.Indent"><severity>4</severity></rule>
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"><severity>4</severity></rule>
+    <rule ref="PSR2.Methods.FunctionCallSignature.Indent"><severity>4</severity></rule>
+    <rule ref="PSR2.Classes.PropertyDeclaration.Underscore"><severity>4</severity></rule>
+    <rule ref="Generic.PHP.LowerCaseConstant.Found"><severity>4</severity></rule>
+    <rule ref="Squiz.ControlStructures.ControlSignature"><severity>4</severity></rule>
+</ruleset>

--- a/scripts/hostis
+++ b/scripts/hostis
@@ -1,24 +1,40 @@
 #!/bin/bash
 
-if [ -n "${1}" ]; then
+# Updates the hostname of this PalMA station to the first argument of this script
+# Resets the host in /etc/hostname and /etc/hosts
+# Resets the station name in /var/www/html/palma.ini
+#
+# NOTE: Expects hostnames of the form "lc00" and expects station names to begin with "LC "
 
-    name=${1}
-    name_uc=`echo "LC "${name:2:3}`
+usage() {
+    echo "Updates the hostname of this PalMA station"
+    echo "Usage: hostis lc<station-number>"
+    if [ ! -z "$1" ]
+    then
+        echo
+        echo "$1"
+        echo
+    fi
+    exit 1
+}
 
-    files=("/etc/hostname" "/etc/hosts" "/var/www/html/palma.ini")
+name="$1"
+files=("/etc/hostname" "/etc/hosts" "/var/www/html/palma.ini")
 
-    for i in "${files[@]}"
-    do
-    file="$i"
-        if [ -f $file ]
-            then
-                sed -i 's/lc[0-9][0-9]/'$name'/g' $file
-                sed -i 's/LC [0-9][0-9]/'"$name_uc"'/g' $file
-            else
-                echo "File with filename $file does not exist."
-        fi
-    done
-
-else
-    echo "Nothing changed, no name specified. Please enter command like this: hostis lc08."
+if [ -z "$name" ]
+then
+    usage "Nothing changed, no name specified. Please enter command like this: hostis lc08."
 fi
+
+name_uc="LC ${name:2:3}"
+
+for file in "${files[@]}"
+do
+    if [ -f "$file" ]
+    then
+        sed -i "s/lc[0-9][0-9]/$name/g" "$file"
+        sed -i "s/LC [0-9][0-9]/$name_uc/g" "$file"
+    else
+        echo "File with filename $file does not exist."
+    fi
+done

--- a/scripts/startvncserver
+++ b/scripts/startvncserver
@@ -2,9 +2,11 @@
 
 # startvncserver - start a VNC server
 
-basedir=`dirname $0`
-basedir=`cd $basedir && cd .. && pwd`
+basedir=$(dirname "$0")
+basedir=$(cd "$basedir" && cd .. && pwd)
 
-export DISPLAY=`grep ^id $basedir/palma.ini|perl -pe 's/^[^=]*=[ ]*["]?([^"]*)["]?/\1/'`
+
+export DISPLAY
+DISPLAY=$(grep "^id" "$basedir/palma.ini"|perl -pe 's/^[^=]*=[ ]*["]?([^"]*)["]?/\1/')
 
 exec x11vnc -forever -nopw -shared -xdamage -allow localhost

--- a/scripts/startx
+++ b/scripts/startx
@@ -42,17 +42,18 @@ if test -d /sys/bus/pci; then
     echo auto >/sys/bus/pci/devices/0000:00:1d.0/power/control
 fi
 
-basedir=`dirname $0`
-basedir=`cd "$basedir" && cd .. && pwd`
+basedir=$(dirname "$0")
+basedir=$(cd "$basedir" && cd .. && pwd)
 
 cd "$basedir"
 
 inifile="$basedir/palma.ini"
 
 # Get some configuration parameters from ini file.
-export DISPLAY=`grep "^id[ ]*=" "$inifile"|perl -pe 's/^[^=]*=[ ]*["]?([^"]*)["]?/\1/'`
-start_url=`grep "^start_url[ ]*=" "$inifile"|perl -pe 's/^[^=]*=[ ]*["]?([^"]*)["]?/\1/'`
-theme=`grep "^theme[ ]*=" "$inifile"|perl -pe 's/^[^=]*=[ ]*["]?([^"]*)["]?/\1/'`
+export DISPLAY
+DISPLAY=$(grep "^id[ ]*=" "$inifile"|perl -pe 's/^[^=]*=[ ]*["]?([^"]*)["]?/\1/')
+start_url=$(grep "^start_url[ ]*=" "$inifile"|perl -pe 's/^[^=]*=[ ]*["]?([^"]*)["]?/\1/')
+theme=$(grep "^theme[ ]*=" "$inifile"|perl -pe 's/^[^=]*=[ ]*["]?([^"]*)["]?/\1/')
 background="${start_url}theme/${theme}/background.png"
 screensaver="${start_url}theme/${theme}/screensaver.php"
 
@@ -66,13 +67,13 @@ runx() {
 }
 
 # Get HOME directory of $user.
-userhome=`su -c pwd -s /bin/sh -l $user`
+userhome=$(su -c pwd -s /bin/sh -l "$user")
 
 # Allow X server on display :0 to start.
 /bin/sleep 3
 
 # Start X server.
-/usr/bin/Xorg $DISPLAY -verbose 0 -nolisten tcp vt8 &
+/usr/bin/Xorg "$DISPLAY" -verbose 0 -nolisten tcp vt8 &
 
 # Allow X server to start before continuing.
 /bin/sleep 5
@@ -101,7 +102,7 @@ runx "/usr/bin/xset s off"
 rm palma.db
 
 # Create directory for application settings if needed.
-mkdir -p $userhome/.config
+mkdir -p "$userhome/.config"
 
 # Find a web browser which supports JavaScript.
 # TODO: try other lightweight browsers.
@@ -109,14 +110,14 @@ webbrowser=/bin/false
 if test -f /usr/bin/dwb; then
     webbrowser=dwb
     # Run dwb with PalMA compatible settings.
-    rm -rf $userhome/.config/dwb
-    cp -a settings/dwb $userhome/.config
+    rm -rf "$userhome/.config/dwb"
+    cp -a settings/dwb "$userhome/.config"
 elif test -f /usr/bin/midori; then
     webbrowser=midori
 fi
 
 # Fix ownership of directory for application settings.
-chown -R $user:$user $userhome/.config
+chown -R "$user:$user" "$userhome/.config"
 
 # 0=initial state
 # 1=screen saver running
@@ -129,7 +130,7 @@ set +x
 while true; do
 
     if test -f palma.db; then
-        usercount=`sqlite3 palma.db "select count(*) from user"`
+        usercount=$(sqlite3 palma.db "select count(*) from user")
     else
         usercount=0
     fi
@@ -160,7 +161,7 @@ while true; do
         if test "$usercount" = '0'; then
             # There is still no user connected.
             # The screensaver should be running. If not: restart it.
-            if !(ps x|grep $webbrowser|grep -v --quiet grep); then
+            if ! pgrep "$webbrowser" >/dev/null; then
                 # Webbrowser was killed (software bug). Restart it.
                 date +"%F %T $webbrowser was killed"
                 state="0"
@@ -183,8 +184,8 @@ while true; do
             state="0"
             continue
         else
-            ACTIVITY=`date -r last_activity '+%s'`
-            NOW=`date '+%s'`
+            ACTIVITY=$(date -r last_activity '+%s')
+            NOW=$(date '+%s')
             DIFF=$((NOW - ACTIVITY))
             if test $((DIFF / 60)) -ge "$TIMEOUT"; then
                 # Users are still connected but for some time no longer active.


### PR DESCRIPTION
* startvncserver: s/backtick/$()/
* hostis: Document and structure hostis script
* startx: s/backtick/$() s/ps -x|grep/pgrep/
  * xorg depdends on udev depends on procps contains pgrep, so pgrep should be available
* split export DISPLAY=$(...) into export and assign
* Make travis work with shellcheck, check /scripts/*
* Stub of a set of UBMA-specific rules for php codesniffer

Signed-off-by: Konstantin Baierer <konstantin.baierer@bib.uni-mannheim.de>