### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,17 @@
 # Travis configuration for PalMA
 
-# TODO:
-# Errors from docs/dist/pre-commit.sh are currently ignored
-# because there are too many coding violations in PHP code.
-
-sudo: false
-
 language: php
 
+sudo: required
+dist: trusty
+
 # php-codesniffer is used for the PSR-2 conformance test.
-addons:
-  apt:
-    packages:
-      - php-codesniffer
-      - libperl-critic-perl
-      - shellcheck
+# Need the wily repos for shellcheck
+before_install:
+  - echo "deb http://archive.ubuntu.com/ubuntu/ wily universe" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -yq php-codesniffer libperl-critic-perl shellcheck
 
 script:
-      - docs/dist/pre-commit.sh . || echo Ignored errors
-      - docs/dist/pre-push.sh
+  - bash docs/dist/pre-commit.sh .
+  - bash docs/dist/pre-push.sh

--- a/docs/dist/php-codesniffer.sh
+++ b/docs/dist/php-codesniffer.sh
@@ -25,7 +25,7 @@
 #------------------------------------------------------------------------------
 
 DIR="$(dirname "$(readlink -f "$0")")"
-PHP_CODE_STANDARD=${PHP_CODE_STANDARD:-PSR2}
+PHP_CODE_STANDARD=${PHP_CODE_STANDARD:-$DIR}
 CS_PHAR="$DIR/phpcs.phar"
 CS_URL='https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar'
 
@@ -39,4 +39,4 @@ if [[ -z "$CODE_SNIFFER" ]];then
     CODE_SNIFFER="php $CS_PHAR"
 fi
 
-$CODE_SNIFFER --standard="$PHP_CODE_STANDARD" "$@"
+$CODE_SNIFFER --standard="$PHP_CODE_STANDARD" -s "$@"

--- a/docs/dist/pre-commit.sh
+++ b/docs/dist/pre-commit.sh
@@ -7,7 +7,7 @@
 # SYNOPSIS
 #         make .git/hooks/pre-commit
 #         # or
-#         ln -s ../../pre-commit.sh .git/hooks
+#         ln -s ../../docs/dist/pre-commit.sh .git/hooks/pre-commit
 #
 #         git add ... && git commit;
 #
@@ -50,10 +50,12 @@ if [[ "${#staged_php[@]}" -ne 0 ]];then
 fi
 
 # If any Shell (bash) scripts are staged
-staged_shell=($($git_diff|grep '\.sh$'))
+staged_shell=()
+staged_shell+=($($git_diff|grep '\.sh$'))
+staged_shell+=($($git_diff|grep '^\(./\)\?scripts/'))
 if [[ "${#staged_shell[@]}" -ne 0 ]];then
     if which shellcheck >/dev/null; then
-        out=$(shellcheck --shell bash "${staged_shell[@]}")
+        out=$(shellcheck --shell=bash "${staged_shell[@]}")
         if [[ ! -z "$out" ]];then
             echo "$out";
             exit 1;

--- a/docs/dist/ruleset.xml
+++ b/docs/dist/ruleset.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<ruleset name="ubma-phpcs-rules">
+    <description>UB Mannheim PHP code checking rules</description>
+    <!-- Include the whole PSR-2 standard -->
+    <rule ref="PSR2">
+        <!-- https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php#L177 -->
+        <exclude name="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace"/>
+        <!-- https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php -->
+        <exclude name="Generic.Functions.FunctionCallArgumentSpacing"/>
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+        <exclude name="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed"/>
+    </rule>
+    <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect"><severity>4</severity></rule>
+    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace.Indent"><severity>4</severity></rule>
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"><severity>4</severity></rule>
+    <rule ref="PSR2.Methods.FunctionCallSignature.Indent"><severity>4</severity></rule>
+    <rule ref="PSR2.Classes.PropertyDeclaration.Underscore"><severity>4</severity></rule>
+    <rule ref="Generic.PHP.LowerCaseConstant.Found"><severity>4</severity></rule>
+    <rule ref="Squiz.ControlStructures.ControlSignature"><severity>4</severity></rule>
+</ruleset>


### PR DESCRIPTION
- Make travis work with shellcheck, check /scripts/*
- Stub of a set of UBMA-specific rules for php codesniffer

These changes are part of https://github.com/UB-Mannheim/PalMA/pull/22/commits/eb6dc677f3b6cd39e040957c2ec905c8f82d4c95
Signed-off-by: Konstantin Baierer konstantin.baierer@bib.uni-mannheim.de

Signed-off-by: Philipp Zumstein zuphilip@gmail.com
