### PR TITLE
Fix CircleCI by allowing also non-signed commits

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,5 @@ test:
     # Errors from docs/dist/pre-commit.sh are currently ignored
     # because there are too many coding violations in PHP code.
     - docs/dist/pre-commit.sh . || echo "Ignore codesniffer errors"
-    # Errors from docs/dist/pre-push.sh are currently ignored
-    # because merge commits from github aren't signed
-    #- docs/dist/pre-push.sh || echo "Ignore non-signed commits"
     # Unit test the PHP scripts
     - docs/dist/run-unittests.sh

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,6 @@ test:
     - docs/dist/pre-commit.sh . || echo "Ignore codesniffer errors"
     # Errors from docs/dist/pre-push.sh are currently ignored
     # because merge commits from github aren't signed
-    - docs/dist/pre-push.sh || echo "Ignore non-signed commits"
+    #- docs/dist/pre-push.sh || echo "Ignore non-signed commits"
     # Unit test the PHP scripts
     - docs/dist/run-unittests.sh


### PR DESCRIPTION
This was already previously deactivated by the || with an echo
command, because also the automatic merge commits from
GitHub itself will not be signed.