### PR TITLE
Remove unused import statements

### DIFF
--- a/install
+++ b/install
@@ -3,8 +3,8 @@
 
 from __future__ import print_function
 
-import argparse, grp, os, platform, pwd, re, shutil, socket, sys, tempfile
-from subprocess import call, check_call, check_output, CalledProcessError
+import argparse, os, platform, pwd, shutil, socket, sys
+from subprocess import call, check_call, check_output
 
 ################################################################################
 ## command line parsing


### PR DESCRIPTION
This fixes recommendations from LGTM:

    Import of 'grp' is not used.
    [...]

Signed-off-by: Stefan Weil <sw@weilnetz.de>