### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/php-gettext/gettext.php
+++ b/php-gettext/gettext.php
@@ -39,16 +39,16 @@ class gettext_reader {
 
    //private:
   var $BYTEORDER = 0;        // 0: low endian, 1: big endian
-  var $STREAM = NULL;
+  var $STREAM = null;
   var $short_circuit = false;
   var $enable_cache = false;
-  var $originals = NULL;      // offset of original table
-  var $translations = NULL;    // offset of translation table
-  var $pluralheader = NULL;    // cache header field for plural forms
+  var $originals = null;      // offset of original table
+  var $translations = null;    // offset of translation table
+  var $pluralheader = null;    // cache header field for plural forms
   var $total = 0;          // total string count
-  var $table_originals = NULL;  // table for original strings (offsets)
-  var $table_translations = NULL;  // table for translated strings (offsets)
-  var $cache_translations = NULL;  // original -> translation mapping
+  var $table_originals = null;  // table for original strings (offsets)
+  var $table_translations = null;  // table for translated strings (offsets)
+  var $cache_translations = null;  // original -> translation mapping
 
 
   /* Methods */
@@ -410,7 +410,7 @@ class gettext_reader {
   function pgettext($context, $msgid) {
     $key = $context . chr(4) . $msgid;
     $ret = $this->translate($key);
-    if (strpos($ret, "\004") !== FALSE) {
+    if (strpos($ret, "\004") !== false) {
       return $msgid;
     } else {
       return $ret;
@@ -420,7 +420,7 @@ class gettext_reader {
   function npgettext($context, $singular, $plural, $number) {
     $key = $context . chr(4) . $singular;
     $ret = $this->ngettext($key, $plural, $number);
-    if (strpos($ret, "\004") !== FALSE) {
+    if (strpos($ret, "\004") !== false) {
       return $singular;
     } else {
       return $ret;


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!