### PR TITLE
Check permission for control commands

### DIFF
--- a/DBConnector.class.php
+++ b/DBConnector.class.php
@@ -125,6 +125,19 @@ eod;
         return $ip;
     }
 
+    public function checkPermission()
+    {
+        $ip = $this->ipAddress();
+        $ip_list = array();
+        $rows = $this->query("SELECT address FROM address");
+        while ($row = $rows->fetchArray(SQLITE3_ASSOC)) {
+            array_push($ip_list, $row['address']);
+        }
+        $rows->finalize();
+        $allowed = in_array($ip, $ip_list);
+        return $allowed;
+    }
+
     public function addUser($username, $address, $device = 'laptop')
     {
         // Add a new user with his/her address and the device to the database.

--- a/control.php
+++ b/control.php
@@ -5,9 +5,6 @@
 
 // Authors: Alexander Wagner, Stefan Weil
 
-// TODO: Authentisierung. Funktioniert hier nicht mit auth.php,
-// daher vielleicht über Datenbankabfrage.
-
 // Test whether the script was called directly (used for unit test). Use some
 // heuristics to detect whether we are not running in a web application.
 if (isset($unittest)) {
@@ -345,7 +342,6 @@ function createNewWindowSafe($db, $w)
     createNewWindow($db, $window);
 }
 
-
 function createNewWindow($db, $w)
 {
     // '$w' already contains 'file', 'handler' and 'date'.
@@ -568,7 +564,9 @@ function processRequests($db)
     }
 } // processRequests
 
-processRequests($db);
+if ($db->checkPermission() || $unittest[__FILE__]) {
+    processRequests($db);
+}
 
 if ($unittest[__FILE__]) {
     // Experimental: Get function call from startx.


### PR DESCRIPTION
PalMA now allows commands only from IP addresses which were registered before.
This fixes an old TODO and should terminate the current hacks.

Signed-off-by: Stefan Weil <sw@weilnetz.de>