### PR TITLE
skip empty uploads silently

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -1,13 +1,13 @@
 <?php
 
-// Copyright (C) 2014-2015 Universitätsbibliothek Mannheim
+// Copyright (C) 2014-2023 Universitätsbibliothek Mannheim
 // See file LICENSE for license details.
 
 require_once('globals.php');
 
 if (empty($_FILES)) {
-    $error = 99;
-    $filename = 'unknown';
+    trace("skipping empty upload request.");
+    return;
 } else {
     $error = $_FILES['file']['error'];
     $filename = $_FILES['file']['name'];


### PR DESCRIPTION
Current error handling for the "default" error value (opening separate browser window) isn't helpful.
My suggestion is to skip empty upload requests generally.